### PR TITLE
Add SaaSCity

### DIFF
--- a/directories/s.ts
+++ b/directories/s.ts
@@ -20,6 +20,15 @@ export const directories: Directory[] = [
         "pricing": "Free"
     },
     {
+        "name": "SaaSCity",
+        "link": "https://saascity.io/",
+        "submission_link": "https://saascity.io/submit",
+        "domain_rating": 46.0,
+        "monthly_visits": 200,
+        "submission_experience": "Good",
+        "pricing": "Free"
+    },
+    {
         "name": "SaasHub",
         "link": "https://www.saashub.com/",
         "submission_link": "https://www.saashub.com/submit",


### PR DESCRIPTION
Adds **SaaSCity** to `directories/s.ts` (alphabetical, before SaasHub).

- Site: https://saascity.io
- Submit: https://saascity.io/submit
- Gamified SaaS directory where every listing becomes a building on a live isometric city map.
- Domain Rating 46 (Ahrefs), free listing, dofollow, every submission manually reviewed inside 24h.

Happy to adjust the wording or move the row if it belongs somewhere else in the list.
